### PR TITLE
FIX: Change type for body to LargeBinaryArray.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! ```rust
 //! use std::io::{BufReader, Cursor, Read};
 //!
-//! use arrow::array::{BinaryArray, StringArray};
+//! use arrow::array::{LargeBinaryArray, StringArray};
 //! use parquet::arrow::{arrow_reader::ParquetRecordBatchReaderBuilder, ArrowWriter};
 //! use tempfile::tempfile;
 //! use warc_parquet::{parquet::basic::Compression, WarcToArrowReader, WARC_1_0_SCHEMA};
@@ -80,9 +80,9 @@
 //!         .column_by_name("body")
 //!         .unwrap()
 //!         .as_any()
-//!         .downcast_ref::<BinaryArray>()
+//!         .downcast_ref::<LargeBinaryArray>()
 //!         .unwrap(),
-//!     &BinaryArray::from_vec(vec![b"Hello, world!"])
+//!     &LargeBinaryArray::from_vec(vec![b"Hello, world!"])
 //! );
 //! # }
 //! ```

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,7 +5,7 @@ use warc::{BufferedBody, Record, StreamingIter, WarcHeader, WarcReader};
 
 use crate::{
     arrow::{
-        array::{ArrayRef, BinaryArray, StringArray, TimestampMillisecondArray, UInt32Array},
+        array::{ArrayRef, LargeBinaryArray, StringArray, TimestampMillisecondArray, UInt32Array},
         datatypes::SchemaRef,
         record_batch::RecordBatch,
     },
@@ -416,7 +416,7 @@ fn build_record_batch(
             "body" => {
                 let body_values: Vec<_> = records.iter().map(|record| record.body()).collect();
 
-                Arc::new(BinaryArray::from(body_values))
+                Arc::new(LargeBinaryArray::from(body_values))
             }
 
             _ => unimplemented!(),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -36,6 +36,6 @@ lazy_static! {
             Field::new("segment_number", DataType::UInt32, true),
             Field::new("segment_origin_id", DataType::Utf8, true),
             Field::new("segment_total_length", DataType::UInt32, true),
-            Field::new("body", DataType::Binary, true),
+            Field::new("body", DataType::LargeBinary, true),
         ]));
 }


### PR DESCRIPTION
When migrating lots of huge private warc files, I noticed that it's possible for a chunk to exceed u32 memory limit of BinaryArray within the default batch size. Instead of changing the batch size, I decided to change typing - hopefully this makes the project more stable in this specific case.